### PR TITLE
Fixing GTK build

### DIFF
--- a/emu-nwaccess/snes9x-nwaccess.cpp
+++ b/emu-nwaccess/snes9x-nwaccess.cpp
@@ -201,7 +201,11 @@ bool	S9xNWAccessStart()
 bool	S9xNWAccessStop()
 {
     NetworkAccessData.stopRequest = true;
+    #ifdef __WIN32__
     WaitForSingleObject((HANDLE)NetworkAccessData.thread, 100);
+    #elif defined(SNES9X_GTK)
+    pthread_timedjoin_np((HANDLE)NetworkAccessData.thread, NULL, 100);
+    #endif
     return true;
 }
 

--- a/emu-nwaccess/snes9x-nwaccess.cpp
+++ b/emu-nwaccess/snes9x-nwaccess.cpp
@@ -203,8 +203,8 @@ bool	S9xNWAccessStop()
     NetworkAccessData.stopRequest = true;
     #ifdef __WIN32__
     WaitForSingleObject((HANDLE)NetworkAccessData.thread, 100);
-    #elif defined(SNES9X_GTK)
-    pthread_timedjoin_np((HANDLE)NetworkAccessData.thread, NULL, 100);
+    // #elif defined(SNES9X_GTK)
+    // pthread_timedjoin_np((HANDLE)NetworkAccessData.thread, NULL, 100);
     #endif
     return true;
 }

--- a/emu-nwaccess/snes9x-nwaccess.cpp
+++ b/emu-nwaccess/snes9x-nwaccess.cpp
@@ -203,8 +203,6 @@ bool	S9xNWAccessStop()
     NetworkAccessData.stopRequest = true;
     #ifdef __WIN32__
     WaitForSingleObject((HANDLE)NetworkAccessData.thread, 100);
-    // #elif defined(SNES9X_GTK)
-    // pthread_timedjoin_np((HANDLE)NetworkAccessData.thread, NULL, 100);
     #endif
     return true;
 }

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -80,6 +80,7 @@ list(APPEND SOURCES src/gtk_display_driver_opengl.cpp
                     ../vulkan/slang_preset_ini.hpp
                     src/gtk_shader_parameters.cpp
                     ../emu-nwaccess/snes9x-nwaccess.cpp
+                    ../emu-nwaccess/snes9x-nwaccess.h
                 )
 list(APPEND INCLUDES ../emu-nwaccess/emulator-networkaccess/c_includes)
 list(APPEND INCLUDES ../emu-nwaccess/emulator-networkaccess/generic\ poll\ server)
@@ -408,6 +409,7 @@ if(USE_SLANG)
     target_link_libraries(slang_test PRIVATE ${LIBS})
 endif()
 
+target_include_directories(snes9x-gtk PUBLIC "../emu-nwaccess/")
 target_include_directories(snes9x-gtk PUBLIC "../emu-nwaccess/emulator-networkaccess/generic poll server/")
 target_include_directories(snes9x-gtk PUBLIC "../emu-nwaccess/emulator-networkaccess/c_includes/")
 

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -78,7 +78,11 @@ list(APPEND SOURCES src/gtk_display_driver_opengl.cpp
                     ../vulkan/slang_helpers.hpp
                     ../vulkan/slang_preset_ini.cpp
                     ../vulkan/slang_preset_ini.hpp
-                    src/gtk_shader_parameters.cpp)
+                    src/gtk_shader_parameters.cpp
+                    ../emu-nwaccess/snes9x-nwaccess.cpp
+                )
+list(APPEND INCLUDES ../emu-nwaccess/emulator-networkaccess/c_includes)
+list(APPEND INCLUDES ../emu-nwaccess/emulator-networkaccess/generic\ poll\ server)
 
 if(USE_SLANG)
     list(APPEND SOURCES ../shaders/slang.cpp)
@@ -403,6 +407,9 @@ if(USE_SLANG)
     target_compile_definitions(slang_test PRIVATE ${DEFINES})
     target_link_libraries(slang_test PRIVATE ${LIBS})
 endif()
+
+target_include_directories(snes9x-gtk PUBLIC "../emu-nwaccess/emulator-networkaccess/generic poll server/")
+target_include_directories(snes9x-gtk PUBLIC "../emu-nwaccess/emulator-networkaccess/c_includes/")
 
 install(TARGETS snes9x-gtk)
 install(FILES ../data/cheats.bml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${CMAKE_INSTALL_DATADIR})


### PR DESCRIPTION
Build still crashes because of the getpeername() function in generic_poll_server.c.
Commenting it fixes it 